### PR TITLE
adding newline to logging writes

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ type leveledLogger struct {
 
 func (l *leveledLogger) write(level string, format string, items ...interface{}) {
 	message := fmt.Sprintf(format, items...)
-	fmt.Fprintf(l.output, "%s [%s] %s", level, l.tag, message)
+	fmt.Fprintf(l.output, "%s [%s] %s\n", level, l.tag, message)
 }
 
 func (l *leveledLogger) Debugf(format string, items ...interface{}) {


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`36fd475`] | adding the newline character to logger writes |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |

[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`36fd475`]: https://github.com/dadleyy/gendry/commit/36fd47594de1e14e42c46611530b8b6f9cb0459e